### PR TITLE
Adds semaphore ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [![Stories in Ready](https://badge.waffle.io/troops2devs/minutes.png?label=ready&title=Ready)](https://waffle.io/troops2devs/minutes)
+
+[![Build Status](https://semaphoreci.com/api/v1/projects/f20441fe-f680-4297-b794-04fcd8b8be36/466891/badge.svg)](https://semaphoreci.com/omarca/minutes)
+
 # Minutes
 
 > Minutes is a simple app that allows resource teachers to track and log the minutes they serve their students on a weekly basis.


### PR DESCRIPTION
Adds semaphore cr badge to README. Continuos integration is now setup as well as continuous deployment from sepmaphore to heroku.